### PR TITLE
🐛 Fix compilation error under gcc-12

### DIFF
--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -225,7 +225,7 @@ public:
 
     static void swapRows(gf2Mat& matrix, const std::size_t row1, const std::size_t row2) {
         for (std::size_t col = 0; col < matrix.at(0).size(); col++) {
-            std::swap(matrix.at(row1).at(col), matrix.at(row2).at(col));
+            std::vector<bool>::swap(matrix.at(row1).at(col), matrix.at(row2).at(col));
         }
     }
 


### PR DESCRIPTION
## Description

This PR fixes a compilation error that recently popped up with the addition of gcc 12 to Ubuntu 22.04 GitHub runners.
The main reason for the failure is that the C++ standard does not mandate that `std::swap` works on `std::vector<bool>` since bit vectors are "special". See https://stackoverflow.com/questions/58660207/why-doesnt-stdswap-work-on-vectorbool-elements-under-clang-win for some more context.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
