### PR TITLE
qiskit version cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "qiskit-aer>=0.11"
+    "qiskit-aer>=0.11, <0.12"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Description

add qiskit version cap as quickfix to the ecc-framework breaking.

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
