### PR TITLE
fix zenodo link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ decoder.run(distance=d, error_rate=p, nr_sims=nr_sims)
 ```
 
 The dataset used in the paper evaluation on decoding quantum color codes is available on Zenodo:
-[![a](https://img.shields.io/static/v1?label=DOI&message=10.5281/zenodo.5522029&color=inactive&style=flat-square)](https://doi.org/10.5281/zenodo.5522029)
+[![a](https://img.shields.io/static/v1?label=DOI&message=10.5281/zenodo.7760135&color=inactive&style=flat-square)](https://doi.org/10.5281/zenodo.7760135)
 
 ### Example for applying error correction to a circuit
 


### PR DESCRIPTION
## Description

Fixes zenodo link in readme

## Checklist:
- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
