### PR TITLE
🩹 workaround for qiskit-aer and qiskit-terra raising a warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,15 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "qiskit>=0.42.0",
     "z3-solver~=4.11.0",
     "qecsim",
     "ldpc>=0.1.50",
     "numpy",
+    # temporary workaround for a deprecation warning within qiskit-aer<=0.12.0 in combination with qiskit-terra>=0.24.0
+    # once qiskit-aer>=0.12.1 is released, this can be removed completely
+    # this should be triggered automatically by dependabot
+    "qiskit-terra>=0.23.0,<0.24.0",
+    "qiskit-aer>=0.12.0,<0.12.1",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Description

This resolves the CI that has been stuck for weeks on a small incompatibility between the latest qiskit-terra and qiskit-aer versions. The underlying bug has already been fixed upstream in qiskit-aer and will be part of `qiskit-aer==0.12.1`.
At that point, a dependabot update should trigger here and the upper caps on the `qiskit-terra` and `qiskit-aer` versions can be removed again.

As an additional change, this PR changes the dependencies to explicitly pull qiskit-terra and qiskit-aer instead of all of qiskit, which should make the overall package a little more lightweight.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [X] The pull request only contains commits that are related to it.
- [X] I have added appropriate tests and documentation.
- [X] I have made sure that all CI jobs on GitHub pass.
- [X] The pull request introduces no new warnings and follows the project's style guidelines.
